### PR TITLE
README and run a single file using the main script

### DIFF
--- a/PICTestControlSoftware.pyw
+++ b/PICTestControlSoftware.pyw
@@ -1,13 +1,18 @@
 """
-This is the file that should be run if running in standalone mode
+This is the main file that should be run to start the program
 Since this is a .pyw file, when you create a shortcut to this file, no console will show up with the GUI
 """
 
 import matplotlib
+import sys
 
-# matplotlib backend needs to be changed because of GitHub issue #20
-matplotlib.use("WXAgg")
-
+# if there are args on the command line, you probably just want to run a config file
 if __name__ == "__main__":
-    import src.GUI.GuiMainApp as GUIMainApp
-    GUIMainApp.main()
+    # matplotlib backend needs to be changed because of GitHub issue #20
+    matplotlib.use("WXAgg")
+    if len(sys.argv) > 1:
+        import src.GUI.RunAConfigFileMain as RunAConfigFileMain
+        RunAConfigFileMain.main(sys.argv)
+    else:
+        import src.GUI.GuiMainApp as GUIMainApp
+        GUIMainApp.main()

--- a/README.md
+++ b/README.md
@@ -1,74 +1,33 @@
-# Design of PTCS
-#### Introduction
+# **P**IC **T**est **C**ontrol **S**oftware
 
-###### What is *PTCS* ?
-The **P**IC **T**est **C**ontrol **S**oftware project is inspired by the [ProberControl](https://probercontrol.github.io/ProberControl/index.html) project created by Columbia University’s Lightwave Research Laboratory and is being developed by the Center for Detectors at Rochester Institute of Technology.
+## What is *PTCS* ?
+PTCS is a software tool that lets a user create and run tests by remotely connecting to measurement instruments and integrated circuits. 
 
-###### What is a Prober Controller?
-In this context, a Prober Controller is a piece of software that can automatically:
-* Manipulate hardware
-* Collect sensor data
-* Analyze collected data
-* Produce an output that is human readable and highlights interesting features
-* Store the output in a logical manner for future analysis
+PTCS is being developed by the Center for Detectors at Rochester Institute of Technology
 
-###### How Does PTCS differ from ProberControl?
-While ProberControl focuses on the testing of wafer devices, PTCS places emphasis on package level testing. However, PTCS is flexible enough that wafer testing should be possible in the future if the need arises.
+#### Features of PTCS
+* Create, save and load a queue of pre-built tests
+* Open result files through the UI
+* Build a test through a GUI
 
-###### Where Can I get PTCS?
+#### Where Can I get PTCS?
 PTCS is currently available from the [Future Photon Initiative public GitHub repository.](https://github.com/FuturePhotonInitiative/PTCS)
 
-* * *
-#### Anatomy of PTCS
-###### Launcher
-The PTCS launcher is the entry point for execution and is responsible for initializing experiment prerequisites. This file is called Prober.py and is
-executed using a python 2.7 interpreter. The launcher will expect the location of a valid [configuration file](#configs) to be passed as an execution argument but
-will prompt the user if one is not specified. Once a valid configuration is loaded, the launcher then stages the [scripts](#experiment). This will ensure that the
-experiment procedures are executed in the order specified, including simultaneously if designated. The launcher then attempts to connect to each of
-[devices](#instruments) specified. If a device is designated as a VISA resource, the launcher will then check if a default connection address is specified and will
-try to connect to that. If a default is not specified or the default cannot be found, the launcher will display a list of the currently connected devices
-and ask the user to input the desired address. If a device is not VISA compliant, such as the Agilent16802A logic analyzer, the launcher will ask the user
-to input an address without displaying the currently connected devices. The details of this address should be documented in the device driver documentation.
-Each device will be added to the [Data Map](#data-map) once initialized. After all the devices have been initialized, the launcher will move any data, if provided, into the
-Initial data section of the Data Map for use by experiment procedures. When the data has all been initialized, the launcher will then begin to execute the tasks
-that were specified in the configurations experiment. Once all tasks have been completed, the launcher will exit and terminate the program.
-###### Configs
-Configuration files are the basis of all PTCS experiments. These files are all JSON formatted and have the following structure
-<div>
-<img src="http://ridl.cfd.rit.edu/images/Prober%20Documentation/Config_Format.jpeg" height="1000" />
-<img src="http://ridl.cfd.rit.edu/images/Prober%20Documentation/Example_Config.png" height="1000" />
-</div>
+## User Documentation
+User facing documentation for the whole EVT project is located in \\hawk\RIDL\internal\projects\EVT\internal documents\Documentation on Hawk
+You should read these documents first. 
 
-Left: Formal definition of configuration file, Right: an example configuration file
-To comply with the JSON format, the official ECMA specification is available [here](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)
+#### User Guide
+EVT6 will guide a user in using all the features of PTCS. This document assumes that all the requirements to run are satisfied.
 
-###### Instruments
-Instruments are a software object that models some external equipment, either physical or virtual. Each of these objects need to follow a few simple design patterns
-to ensure proper compatibility with PTCS. PTCS utilizes Object Orient Programming and therefore the instrument must be represented by a class. In addition to OOP, each
-instrument also must implement python's [*with*](https://docs.python.org/3/whatsnew/2.6.html#pep-343-the-with-statement) pattern, which requires an `__enter__` method
-and an `__exit__` method. Finally, PTCS also expects a few methods used to gather information about a particular device:
-* who_am_i
-  This method should return a string that contains a reference to the type of device and it's connection status.
-* check_connected
-  this method should return a Boolean indicating if the device is currently connected
-* what_can_i
-  this method should return a list of methods in the class that are prepended by the "run_" phrase, for optimal performance this list can be cached for later use
-  the following is an example where methods is a static list of the Agilent class
- <img src="http://ridl.cfd.rit.edu/images/Prober%20Documentation/Sample_WCI.png" height="100" />
+#### Requirements to Run
+See EVT9 for the python version, pip packages, and supported windows versions to run the software
 
-Any other method that is user exposed, IE not strictly internal, should be prepended by the phrase "run_", this will help the GUI identify options for graphical programming
+#### Running TCL tests
+Currently most use cases for this software have been implemented by writing and auto-generating python scripts. Sometimes it is useful to run a test that communicates with Vivado. Vivado can operate in headless mode by giving it a TCL script. EVT8 has some helpful information about running TCL tests with PTCS
 
-###### Experiment
-The experiment section of the [config file](#configs) is the main logic of the experiment. It defines what needs to be run and when. This can either be python scripts that are executed,
-or any other program. If two tasks share the same order they will be executed at the same time.
-PTCS will not continue to the next stage until all of the tasks in the current stage are complete.
+## Developer Documentation
 
-Scripts are python tasks that can be run by PTCS. These will be passed a data map which contains any data specified in the configuration as well as any data that
-a previous stage may have put there. The script can add and manipulate this data map in any way it chooses. The script must have a static top level method name `main` that
-takes in one parameter (the data map). If the method returns anything it will be ignored, any data that needs to be passed should be put in the data map.
-###### Data Map
-The data map stores data as PTCS moves from stage to stage. This is implemented as a Python dict (aka KV pair, hashmap). The data map will always contain a few sections and
-the rest is up to the developer of the experiment. All sections of the data map should be treated as read only with the one exception of the data section. This object is
-automatically generated by the launcher.
-
-<img src="http://ridl.cfd.rit.edu/images/Prober%20Documentation/Data_Map_Diagram.png" height="500" />
+#### Developer documentation directory
+All the documentation relating to how the code works and how to modify it is located in \\hawk\RIDL\internal\projects\EVT\internal documents\ProberControl Documentation\PTCS Fall2019. This is pretty much a copy of the folder we (Owen and Mark) used in Summer, but it is cleaned up.
+If you have not yet, read and complete everything in the *New Developer Startup Guide* When you have completed this, read through the *Codebase Overview* document. As you read this, it should refer you to every other document in this directory. If it does not, then read those documents anyway. (except all the documents in the *Instrument Connection Documentation* folder. Those are just datasheets for how to connect to the instruments we have in the lab remotely)

--- a/src/GUI/Model/ExperimentResultModel.py
+++ b/src/GUI/Model/ExperimentResultModel.py
@@ -266,4 +266,3 @@ class ExperimentResultsModel:
 
     def get_experiment_results_file_list(self):
         return self.experiments_results_files
-

--- a/src/GUI/RunAConfigFile/Args.py
+++ b/src/GUI/RunAConfigFile/Args.py
@@ -5,7 +5,7 @@ import re
 class Args:
 
     def __init__(self):
-        parser = argparse.ArgumentParser(description="Run experiments")
+        parser = argparse.ArgumentParser(description="Run an Experiment")
         parser.add_argument("-c", "--configFile",
                             help="configuration json file")
         parser.add_argument("-p", "--paramFile", type=argparse.FileType('r'),

--- a/src/GUI/RunAConfigFileMain.py
+++ b/src/GUI/RunAConfigFileMain.py
@@ -3,13 +3,13 @@ import sys
 import types
 import contextlib2
 import imp
-import os
+from os.path import join
 
-from RunAConfigFile.Args import Args
-from RunAConfigFile.DeviceSetup import DeviceSetup
-from Model.ConfigFile import ConfigFile
-from Util.CONSTANTS import SCRIPTS_DIR
-from Util.CONSTANTS import JSON_SCHEMA_FILE_NAME
+from src.GUI.RunAConfigFile.Args import Args
+from src.GUI.RunAConfigFile.DeviceSetup import DeviceSetup
+from src.GUI.Model.ConfigFile import ConfigFile
+from src.GUI.Util.CONSTANTS import SCRIPTS_DIR
+from src.GUI.Util.CONSTANTS import JSON_SCHEMA_FILE_NAME
 
 
 def spawn_scripts(scripts, data_map, experiment_result):
@@ -25,7 +25,7 @@ def spawn_scripts(scripts, data_map, experiment_result):
         threads = []  # TODO add multithreading support here
         module = script.source[:-3]
         if module not in [i[0] for i in globals().items() if isinstance(i[1], types.ModuleType)]:
-            globals()[module] = imp.load_source(module, os.path.join(SCRIPTS_DIR, module + '.py'))
+            globals()[module] = imp.load_source(module, join(SCRIPTS_DIR, module + '.py'))
         [i[1] for i in inspect.getmembers(globals()[module], inspect.isfunction) if i[0] is 'main'][0](data_map, experiment_result)
     print "Scripts Completed"
     return
@@ -91,7 +91,3 @@ def main(args, config_manager=None, queue_result=None):
     experiment_result.end_experiment()
     results_manager.save_experiment_result(experiment_result_name, experiment_result)
     print 'Experiment complete, goodbye!'
-
-
-if __name__ == '__main__':
-    main(sys.argv)


### PR DESCRIPTION
Rewrote the README to refer to documentation on Hawk. The README is now formatted for a new developer and tells them what they should do to start contributing. I also refactored the way one can run a single config file without the GUI. Now the user can specify command arguments through PICTestControlSoftware.pyw