### PR TITLE
All files successfully display on the right panel when they are clicked on in the left panel of the results tab, including subdirectory files

### DIFF
--- a/src/GUI/Model/ExperimentResultModel.py
+++ b/src/GUI/Model/ExperimentResultModel.py
@@ -261,3 +261,6 @@ class ExperimentResultsModel:
 
     def get_experiment_results_file_list(self):
         return self.experiments_results_files
+
+    def get_results_dir(self):
+        return self.experiment_results_directory

--- a/src/GUI/UI/ExperimentResults/ExperimentListPanel.py
+++ b/src/GUI/UI/ExperimentResults/ExperimentListPanel.py
@@ -44,12 +44,12 @@ class ExperimentListPanel(DisplayPanel):
 
         # Runs the selected function when an experiment is selected
         self.Bind(wx.EVT_TREE_SEL_CHANGED, self.selected)
-        self.Bind(wx.EVT_BUTTON, self.reload)
+        # self.Bind(wx.EVT_BUTTON, self.reload)
         # self.Bind(wx.EVT_TIMER, self.reload, self.Parent.Parent.Parent.Parent.timer)
 
-        self.timer = wx.Timer(self)
-        self.Bind(wx.EVT_TIMER, self.reload, self.timer)
-        self.timer.Start(5000)
+        # self.timer = wx.Timer(self)
+        # self.Bind(wx.EVT_TIMER, self.reload, self.timer)
+        # self.timer.Start(5000)
 
         self.reload(None)
 

--- a/src/GUI/UI/ExperimentResults/ResultsFileListPanel.py
+++ b/src/GUI/UI/ExperimentResults/ResultsFileListPanel.py
@@ -12,6 +12,7 @@ class ResultsFileListPanel(wx.StaticBox):
         wx.StaticBox.__init__(self, parent)
 
         self.result = None
+        self.displayed_files = []
 
         self.list_box = wx.ListBox(self, style=wx.LB_HSCROLL)
         self.list_box.SetBackgroundColour(CONSTANTS.LIST_PANEL_COLOR)
@@ -35,16 +36,25 @@ class ResultsFileListPanel(wx.StaticBox):
         :param result: The experiment who's results will be displayed
         """
         self.list_box.Clear()
+        self.displayed_files.clear()
         self.result = result
         if self.result is not None:
-            for fil in self.result.get_experiment_results_file_list():
-                self.list_box.Append(fil)
+            self.list_box.Append(self.result.get_results_dir())
+            self.displayed_files.append(self.result.get_results_dir())
+            leng = len(self.result.get_results_dir()) + 1
+
+            for root, dirs, files in os.walk(self.result.get_results_dir()):
+                for name in files:
+                    pat = os.path.join(root, name)
+                    self.list_box.Append(pat[leng:])
+                    self.displayed_files.append(pat)
 
     def on_result_select(self, event):
         """
         Opens the file selected using the operating system, then deselects the selection
         :param event: The event that caused the call
         """
-        file_name = self.result.get_experiment_results_file_list()[self.list_box.GetSelection()]
-        os.startfile("\"{}\"".format(file_name))
+        clicked_label_position = self.list_box.GetSelection()
+
+        os.startfile("\"{}\"".format(self.displayed_files[clicked_label_position]))
         self.list_box.Deselect(self.list_box.GetSelection())


### PR DESCRIPTION
Fixes #23 